### PR TITLE
added HandlerFunc for removing dependency in metric

### DIFF
--- a/app/pkg/metric/handler.go
+++ b/app/pkg/metric/handler.go
@@ -2,8 +2,6 @@ package metric
 
 import (
 	"net/http"
-
-	"github.com/julienschmidt/httprouter"
 )
 
 const (
@@ -13,8 +11,13 @@ const (
 type Handler struct {
 }
 
-// Register TODO Задача №4. fix dependency on httprouter
-func (h *Handler) Register(router *httprouter.Router) {
+// A HandlerFunc is a type that implement of handling an HTTP request.
+type HandlerFunc interface {
+	HandlerFunc(method, path string, handler http.HandlerFunc)
+}
+
+// Register adds the routes for the metric handler to the passed router.
+func (h *Handler) Register(router HandlerFunc) {
 	router.HandlerFunc(http.MethodGet, URL, h.Heartbeat)
 }
 


### PR DESCRIPTION
Пример реализации интерфейса для стандартного роутера
```golang
// WrapServeMux wraps the http.ServeMux to implement the HandlerFunc interface.
type WrapServeMux struct {
	*http.ServeMux
}

// HandlerFunc implements the HandlerFunc interface.
func (s *WrapServeMux) HandlerFunc(method, path string, handler http.HandlerFunc) {
	s.HandleFunc(path, func(w http.ResponseWriter, req *http.Request) {
		if req.Method != method {
			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
			return
		}
		handler.ServeHTTP(w, req)
	})
}
```
#8 